### PR TITLE
Fix stress.json

### DIFF
--- a/stress.json
+++ b/stress.json
@@ -1,5 +1,5 @@
 [
     {"name":"busybox", "args": ["true"]},
-    {"name":"busybox", "args": ["ping", "-c", "5", "google.com"]}
-    {"name":"busybox", "flags": "--log-driver=syslog", "args": ["ping", "-c", "5", "google.com"]}
+    {"name":"busybox", "args": ["ping", "-c", "5", "google.com"]},
+    {"name":"busybox", "flags": ["--log-driver=syslog"], "args": ["ping", "-c", "5", "google.com"]}
 ]


### PR DESCRIPTION
Just tried to run docker-stress, found two issues:

> FATA[0000] invalid character '{' after array element

This was a missing comma

> FATA[0000] json: cannot unmarshal string into Go value of type []string

This was a missing square brackets around flags: argument

This commit fixes both issues. Also, this makes me think you are using
some other json file for the actual testing. I would be much obliged
if you can share it.

Signed-off-by: Kir Kolyshkin <kir@openvz.org>